### PR TITLE
Update due to outdated source.

### DIFF
--- a/content/en/docs/tutorials/server.js
+++ b/content/en/docs/tutorials/server.js
@@ -1,9 +1,19 @@
 var http = require('http');
-
+var requests=0;
+var podname= process.env.HOSTNAME;
+var startTime;
+var host;
 var handleRequest = function(request, response) {
-  console.log('Received request for URL: ' + request.url);
+  response.setHeader('Content-Type', 'text/plain');
   response.writeHead(200);
-  response.end('Hello World!');
-};
+  response.write("Hello Kubernetes bootcamp! | Running on: ");
+  response.write(host);
+  response.end(" | v=1\n");
+  console.log("Running On:" ,host, "| Total Requests:", ++requests,"| App Uptime:", (new Date() - startTime)/1000 , "seconds", "| Log Time:",new Date());
+}
 var www = http.createServer(handleRequest);
-www.listen(8080);
+www.listen(8080,function () {
+    startTime = new Date();;
+    host = process.env.HOSTNAME;
+    console.log ("Kubernetes Bootcamp App Started At:",startTime, "| Running On: " ,host, "\n" );
+});


### PR DESCRIPTION
**Problem:**  
**In repository [tutorials/server.js](https://github.com/kubernetes/website/blob/master/content/en/docs/tutorials/server.js) is seems to be outdated.** 
This is the latest source : [gcr.io/google-samples/kubernetes-bootcamp:v1 image](https://gcr.io/google-samples/kubernetes-bootcamp:v1)'s server.js.

**Proposed Solution:**  
**[tutorials/server.js](https://github.com/kubernetes/website/blob/master/content/en/docs/tutorials/server.js)  should be updated to the [latest source(gcr.io/google-samples/kubernetes-bootcamp:v1)](https://gcr.io/google-samples/kubernetes-bootcamp:v1)'s server.js.**